### PR TITLE
Fix Various Things After Feedback

### DIFF
--- a/src/components/DropdownMenu.vue
+++ b/src/components/DropdownMenu.vue
@@ -53,6 +53,7 @@
         :id="submenuId"
         class="absolute top-0 lg:top-auto left-full text-white lg:text-black"
         @keyup.esc.native="focusButton"
+        @close-menu="$emit('close-menu')"
       />
     </slot>
   </fragment>

--- a/src/components/DropdownMenu.vue
+++ b/src/components/DropdownMenu.vue
@@ -10,19 +10,21 @@
     >
       <slot></slot>
       <template v-if="hasChevron">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 14.739 7.662"
-          aria-hidden="true"
-          focusable="false"
-          class="hidden lg:block w-2 h-2 fill-current absolute mx-auto mt-10 chevron transform transition ease-in-out duration-200 "
-        >
-          <title>Down Chevron</title>
-          <path
+        <div class="absolute flex items-center justify-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 14.739 7.662"
             aria-hidden="true"
-            d="M8.034 7.409a1 1 0 01-1.329 0L.335 1.747A1 1 0 011 0h12.74a1 1 0 01.664 1.747z"
-          ></path>
-        </svg>
+            focusable="false"
+            class="hidden lg:block w-2 h-2 fill-current mx-auto mt-10 chevron transform transition ease-in-out duration-200 "
+          >
+            <title>Down Chevron</title>
+            <path
+              aria-hidden="true"
+              d="M8.034 7.409a1 1 0 01-1.329 0L.335 1.747A1 1 0 011 0h12.74a1 1 0 01.664 1.747z"
+            ></path>
+          </svg>
+        </div>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 8.5 14.1"

--- a/src/components/DropdownSubmenuList.vue
+++ b/src/components/DropdownSubmenuList.vue
@@ -4,6 +4,27 @@
     :class="listClasses"
     :aria-hidden="!open"
   >
+    <li class="lg:hidden mr-0 bg-gray-900" aria-hidden="!open">
+      <button
+        class="tracking-wide font-normal px-5 py-3 flex items-center w-full"
+        @click="$emit('close-menu')"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 8.5 14.1"
+          role="img"
+          aria-hidden="true"
+          aria-labelledby="icon-39"
+          class="w-5 h-5 fill-current"
+        >
+          <title aria-hidden="true">Back</title>
+          <path
+            d="M7.1 14.1L0 7.1 7.1 0l1.4 1.4-5.7 5.7 5.7 5.7-1.4 1.3z"
+          ></path>
+        </svg>
+        <span class="px-4">Back</span>
+      </button>
+    </li>
     <li
       v-for="subcategory in subcategories"
       :key="subcategory.name"
@@ -12,7 +33,7 @@
     >
       <a
         :href="subcategory.url"
-        class="tracking-wide font-normal px-5 py-1 flex items-center"
+        class="tracking-wide font-normal px-5 lg:py-1 py-3 flex items-center"
         :tabindex="!open ? '-1' : null"
       >
         {{ subcategory.name }}

--- a/src/components/HamburgerButton.vue
+++ b/src/components/HamburgerButton.vue
@@ -1,8 +1,8 @@
 <template>
   <button
     aria-label="Open Menu"
-    :aria-expanded="active"
-    class="bg-transparent w-10 h-12 px-2 transition-all ease-in-out duration-200 relative transform text-white"
+    :aria-expanded="active ? 'true' : 'false'"
+    class="bg-transparent w-10 h-12 px-3 transition-all ease-in-out duration-200 relative transform text-white .burger-button"
     :class="{ '-rotate-180': active }"
     @click="$emit('click')"
   >
@@ -10,8 +10,7 @@
       ><span
         class="burger-bar burger-bar--1 transform transition-all duration-200"
         :class="{
-          'rotate-45 translate-y-0': active,
-          '-translate-y-2': !active
+          'rotate-45 translate-y-0': active
         }"
       ></span>
       <span
@@ -21,8 +20,7 @@
       <span
         class="burger-bar burger-bar--3 transform transition-all duration-200"
         :class="{
-          '-rotate-45 translate-y-0': active,
-          'translate-y-2': !active
+          '-rotate-45 translate-y-0': active
         }"
       ></span
     ></span>
@@ -39,9 +37,19 @@ export default {
 };
 </script>
 <style scoped lang="postcss">
+.burger-button {
+  width: 2.625rem;
+}
 .burger-bar {
-  @apply block absolute left-0 right-0 bg-opacity-100 bg-white h-2px w-auto;
+  @apply block absolute left-0 right-0 bg-opacity-100 bg-white w-auto;
+  height: 0.125rem;
   top: 50%;
+}
+[aria-expanded="false"] .burger-bar--1 {
+  --transform-translate-y: -0.45rem;
+}
+[aria-expanded="false"] .burger-bar--3 {
+  --transform-translate-y: 0.45rem;
 }
 .burger-bar--2 {
   transform-origin: 100% 50%;

--- a/src/components/HamburgerButton.vue
+++ b/src/components/HamburgerButton.vue
@@ -2,7 +2,7 @@
   <button
     aria-label="Open Menu"
     :aria-expanded="active ? 'true' : 'false'"
-    class="bg-transparent w-10 h-12 px-3 transition-all ease-in-out duration-200 relative transform text-white .burger-button"
+    class="bg-transparent h-12 px-3 transition-all ease-in-out duration-200 relative transform text-white burger-button"
     :class="{ '-rotate-180': active }"
     @click="$emit('click')"
   >

--- a/src/components/PrimaryNav.vue
+++ b/src/components/PrimaryNav.vue
@@ -43,6 +43,7 @@
         :subcategories="category.subcategories"
         :list-open="openListIndex === index"
         @button-click="dropdownButtonClicked(index)"
+        @close-menu="closeAllDropdowns"
         >{{ category.name }}</DropdownMenu
       >
       <a

--- a/src/components/SecondaryNavList.vue
+++ b/src/components/SecondaryNavList.vue
@@ -1,7 +1,7 @@
 <template>
   <ul
     ref="list"
-    class="flex lg:flex-1 items-center justify-end gap-8"
+    class="flex lg:flex-1 items-center justify-end"
     @focusout="focusOut"
     @keydown.esc="languageDropdownOpen = false"
   >

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -4,10 +4,12 @@
       Skip to Main Content
     </a>
     <div
+      ref="wrapperRef"
       class="bg-gray-900 text-white flex justify-between h-full lg:h-20 items-center px:4 lg:px-10 font-display relative"
       :class="{ 'nav-active': navActive }"
       :inert="searchActive"
       @keydown.esc="navActive = false"
+      @focusout="focusout"
     >
       <HamburgerButton
         class="lg:hidden h-12 px-3"
@@ -81,6 +83,14 @@ export default {
     },
     searchOpened() {
       this.searchActive = true;
+    },
+    focusout(event) {
+      if (
+        this.navActive &&
+        !this.$refs.wrapperRef.contains(event.relatedTarget)
+      ) {
+        this.navActive = false;
+      }
     }
   },
   created() {

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -5,20 +5,20 @@
     </a>
     <div
       ref="wrapperRef"
-      class="bg-gray-900 text-white flex justify-between h-full lg:h-20 items-center px:4 lg:px-10 font-display relative"
+      class="bg-gray-900 text-white flex justify-between h-full lg:h-20 items-center py-3 lg:pl-10 lg:pr-6 pl-2px font-display relative"
       :class="{ 'nav-active': navActive }"
       :inert="searchActive"
       @keydown.esc="navActive = false"
       @focusout="focusout"
     >
       <HamburgerButton
-        class="lg:hidden h-12 px-3"
+        class="lg:hidden h-12"
         :active="navActive"
         @click="navActive = !navActive"
       />
       <TheHeaderLogo
         :lang="currentLanguage"
-        class="lg:w-1/3"
+        class="lg:w-1/3 ml-2 mt-2 lg:mt-0 lg:ml-0"
         :inert="navActive"
       />
       <nav class="lg:contents uppercase">
@@ -26,7 +26,7 @@
         <PrimaryNav
           :categories="primaryNavCategories"
           :languages="languages"
-          class="primary-nav hidden text-white lg:flex lg:w-1/3"
+          class="primary-nav hidden text-white lg:flex"
           :class="{ 'lg:hidden': searchActive }"
           aria-labelledby="primary-nav-label"
         />
@@ -35,6 +35,7 @@
           :languages="languages"
           store-url="#"
           account-url="#"
+          class="lg:ml-12"
           search-input-id="desktop-nav-search-input"
           @search-clicked="searchOpened"
         />


### PR DESCRIPTION
# Fixes various styles after feedback from the team

1. Fixes bug where chevron for dropdown buttons on desktop is too low in Chrome - due to browser bug around buttons in FF & Chrome
1. Adds a back button on mobile
1. Closes mobile menu when focus leaves the header
1. Increases height of secondary menu buttons on mobile
1. adjusts hamburger menu button to be height & width of design
1. Adjusts desktop nav styles so secondary menu doesn't have as large of a gap